### PR TITLE
Adjusted Double Spacing Further

### DIFF
--- a/misqdoc.cls
+++ b/misqdoc.cls
@@ -22,6 +22,8 @@
 \RequirePackage{fancyhdr}
 % Gotta have that double space
 \RequirePackage[doublespacing]{setspace}
+% Adjusting stretch to obtain results similar to MS Word
+\setstretch{2.1}
 
 % Get rid of spacing inside lists
 \RequirePackage{enumitem}


### PR DESCRIPTION
MS Word and setspace package handle double space differently. See here for details:

https://tex.stackexchange.com/questions/13742/what-does-double-spacing-mean

Adjusting setstretch fixes the issue.